### PR TITLE
Change Ass to Asset

### DIFF
--- a/lib/templates/default/plugin.php.mustache
+++ b/lib/templates/default/plugin.php.mustache
@@ -101,7 +101,7 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\editor_assets' );
 /**
  * Get asset file.
  *
- * @param string $handle Ass handle to reference.
+ * @param string $handle Asset handle to reference.
  * @param string $key What do we want to return: version or dependencies.
  */
 function asset_file( $handle, $key ) {


### PR DESCRIPTION
The function is asset_file() so I guess that the comment "Ass handle to reference" should be "Asset handle to reference"